### PR TITLE
Change organization for the apiserver certificate

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -109,7 +109,7 @@ k8s_apiserver_csr_key_algo: "rsa"
 k8s_apiserver_csr_key_size: "2048"
 k8s_apiserver_csr_names_c: "DE"
 k8s_apiserver_csr_names_l: "The_Internet"
-k8s_apiserver_csr_names_o: "Kubernetes"
+k8s_apiserver_csr_names_o: "system:masters" # DO NOT CHANGE!
 k8s_apiserver_csr_names_ou: "BY"
 k8s_apiserver_csr_names_st: "Bayern"
 


### PR DESCRIPTION
According to https://kubernetes.io/docs/setup/best-practices/certificates/#all-certificates the
`kube-apiserver-kubelet-client` needs to have the organization defined as `system:masters`. With the
previous identifier (Kubernetes) there were some permission problems, specifically the ability to
fetch pod logs.

When using `Kubernetes` as organization, the error when fetching the logs for a resource is:

```
Error from server (Forbidden): Forbidden (user=kubernetes, verb=get, resource=nodes, subresource=proxy) ( pods/log nginx)
```

This may be solved by adding a `ClusterRole` with the proxy permissions to the Kubernetes user, but
the Kubernetes' defaults should instead be used for the API server.