### PR TITLE
Add support for IPv6 addresses in certificate generation.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,9 @@ k8s_ca_worker_nodes_group: "k8s_worker"
 # "wg0" (WireGuard), "peervpn0" (PeerVPN) or "tap0".
 k8s_interface: "tap0"
 
+#This overrides the address family which is used for generating the IP addresses within the certificates
+k8s_address_family: ipv4
+
 # Expiry for etcd root certificate
 ca_etcd_expiry: "87600h"
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: ansible.utils
+    version: ">=2.10.3"
+    type: galaxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,9 +8,17 @@
 - name: Generate list of IP addresses and hostnames needed for Kubernetes API server certificate
   set_fact:
     k8sApiHosts: >-
-      {% set comma = joiner(",") %}{% for item in groups[k8s_ca_controller_nodes_group] -%}
-        {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
-      {%- endfor %}{% for item in k8s_apiserver_cert_hosts -%}
+      {% set comma = joiner(",") %}
+      {% if k8s_address_family == "IPv4" %}
+        {%- for item in groups[k8s_ca_controller_nodes_group] -%}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+        {%- endfor -%}
+      {% elif k8s_address_family == "IPv6" %}
+        {%- for item in groups[k8s_ca_controller_nodes_group] -%}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv6.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+        {%- endfor -%}
+      {% endif %}
+      {%- for item in k8s_apiserver_cert_hosts -%}
         {{ comma() }}{{ item }}
       {%- endfor %}
   tags:
@@ -23,20 +31,20 @@
 
 - name: Generate list of IP addresses and hostnames needed for etcd certificate
   set_fact:
-  etcdHosts: >-
-    {% set comma = joiner(",") %}
-    {% if k8s_address_family == "ipv4" %}
-      {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-        {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
-      {%- endfor -%}
-    {% elif k8s_address_family == "ipv6" %}
-      {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-        {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv6.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
-      {%- endfor -%}
-    {% endif %}
-    {%- for item in etcd_cert_hosts -%}
-      {{ comma() }}{{ item }}
-    {%- endfor %}
+    etcdHosts: >-
+      {% set comma = joiner(",") %}
+      {% if k8s_address_family == "ipv4" %}
+        {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+        {%- endfor -%}
+      {% elif k8s_address_family == "ipv6" %}
+        {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv6.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+        {%- endfor -%}
+      {% endif %}
+      {%- for item in etcd_cert_hosts -%}
+        {{ comma() }}{{ item }}
+      {%- endfor %}
   tags:
     - kubernetes-ca
     - kubernetes-ca-etcd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,11 +11,11 @@
       {% set comma = joiner(",") %}
       {% if k8s_address_family == "ipv4" %}
         {%- for item in groups[k8s_ca_controller_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["access_ip"] }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_controller_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | quote }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | quote }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | quote }}{{ comma() }}{{ hostvars[item]["access_ip"] }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | quote }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in k8s_apiserver_cert_hosts -%}
@@ -35,11 +35,11 @@
       {% set comma = joiner(",") %}
       {% if k8s_address_family == "ipv4" %}
         {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["access_ip"] }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | quote }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | quote }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | quote }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | quote }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["access_ip"] }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in etcd_cert_hosts -%}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -266,7 +266,7 @@
       -ca=ca-etcd.pem \
       -ca-key=ca-etcd-key.pem \
       -config=ca-etcd-config.json \
-      -hostname={{ etcdHosts | ansible.utils.ipwrap}} \
+      -hostname={{ etcdHosts | ansible.utils.ipwrap | quote }} \
       -profile=server \
       cert-etcd-server-csr.json \
     | cfssljson -bare cert-etcd-server
@@ -299,7 +299,7 @@
       -ca=ca-etcd.pem \
       -ca-key=ca-etcd-key.pem \
       -config=ca-etcd-config.json \
-      -hostname={{ etcdHosts | ansible.utils.ipwrap }} \
+      -hostname={{ etcdHosts | ansible.utils.ipwrap | quote }} \
       -profile=peer \
       cert-etcd-peer-csr.json \
     | cfssljson -bare cert-etcd-peer
@@ -332,7 +332,7 @@
       -ca=ca-k8s-apiserver.pem \
       -ca-key=ca-k8s-apiserver-key.pem \
       -config=ca-k8s-apiserver-config.json \
-      -hostname={{ k8sApiHosts | ansible.utils.ipwrap }} \
+      -hostname={{ k8sApiHosts | ansible.utils.ipwrap | quote }} \
       -profile=kubernetes \
       cert-k8s-apiserver-csr.json \
     | cfssljson -bare cert-k8s-apiserver
@@ -417,7 +417,7 @@
       -ca=ca-k8s-apiserver.pem \
       -ca-key=ca-k8s-apiserver-key.pem \
       -config=ca-k8s-apiserver-config.json \
-      -hostname={{ hostvars[item]['ansible_hostname'] }},{{ hostvars[item]['ansible_default_ipv6']['address'] }},{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] }} \
+      -hostname={{ hostvars[item]['ansible_hostname'] }},{{ hostvars[item]['ansible_default_ipv6']['address'] | ansible.utils.ipwrap  | quote }},{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | ansible.utils.ipwrap | quote }} \
       -profile=kubernetes \
       cert-{{ item }}-csr.json \
     | cfssljson -bare cert-{{ item }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,13 @@
   set_fact:
     k8sApiHosts: >-
       {% set comma = joiner(",") %}
-      {% if k8s_address_family == "IPv4" %}
+      {% if k8s_address_family == "ipv4" %}
         {%- for item in groups[k8s_ca_controller_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_" + hostvars[item][k8s_interface]]['ipv4']['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
-      {% elif k8s_address_family == "IPv6" %}
+      {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_controller_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv6.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_" + hostvars[item][k8s_interface]]['ipv6']['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in k8s_apiserver_cert_hosts -%}
@@ -35,11 +35,11 @@
       {% set comma = joiner(",") %}
       {% if k8s_address_family == "ipv4" %}
         {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item][k8s_interface]].ipv4.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv6.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item][k8s_interface]].ipv6.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in etcd_cert_hosts -%}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -299,7 +299,7 @@
       -ca=ca-etcd.pem \
       -ca-key=ca-etcd-key.pem \
       -config=ca-etcd-config.json \
-      -hostname={{ etcdHosts | ansible.utils.ipwrap | quote }} \
+      -hostname={{ etcdHosts | quote }} \
       -profile=peer \
       cert-etcd-peer-csr.json \
     | cfssljson -bare cert-etcd-peer
@@ -332,7 +332,7 @@
       -ca=ca-k8s-apiserver.pem \
       -ca-key=ca-k8s-apiserver-key.pem \
       -config=ca-k8s-apiserver-config.json \
-      -hostname={{ k8sApiHosts | ansible.utils.ipwrap | quote }} \
+      -hostname={{ k8sApiHosts | quote }} \
       -profile=kubernetes \
       cert-k8s-apiserver-csr.json \
     | cfssljson -bare cert-k8s-apiserver
@@ -417,7 +417,7 @@
       -ca=ca-k8s-apiserver.pem \
       -ca-key=ca-k8s-apiserver-key.pem \
       -config=ca-k8s-apiserver-config.json \
-      -hostname={{ hostvars[item]['ansible_hostname'] }},{{ hostvars[item]['ansible_default_ipv6']['address'] | ansible.utils.ipwrap  | quote }},{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | ansible.utils.ipwrap | quote }} \
+      -hostname={{ hostvars[item]['ansible_hostname'] }},{{ hostvars[item]['ansible_default_ipv6']['address'] | quote }},{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | quote }} \
       -profile=kubernetes \
       cert-{{ item }}-csr.json \
     | cfssljson -bare cert-{{ item }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -266,7 +266,7 @@
       -ca=ca-etcd.pem \
       -ca-key=ca-etcd-key.pem \
       -config=ca-etcd-config.json \
-      -hostname={{ etcdHosts | ansible.utils.ipwrap }} \
+      -hostname={{ etcdHosts | ansible.utils.ipwrap}} \
       -profile=server \
       cert-etcd-server-csr.json \
     | cfssljson -bare cert-etcd-server
@@ -386,7 +386,7 @@
     - cert-admin-key.pem
     - cert-admin.csr
 
-- name: Generate TLS certificates for Kubernetes worker hosts (kubelet)
+- name: Generate TLS certificates for Kubernetes worker hosts (kubelet) (IPv4)
   shell: >
     set -o errexit; \
     set -o pipefail; \
@@ -394,23 +394,41 @@
       -ca=ca-k8s-apiserver.pem \
       -ca-key=ca-k8s-apiserver-key.pem \
       -config=ca-k8s-apiserver-config.json \
-      - hostname="{{ hostvars[item]['ansible_hostname'] }},
-        {%- if k8s_address_family == "ipv4" %}
-        {{ hostvars[item]['ansible_default_ipv4']['address'] }},
-        {{ hostvars[item][hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address']] }}
-        {%- elif k8s_address_family == "ipv6" %}
-        {{ hostvars[item]['ansible_default_ipv6']['address'] }},
-        {{ hostvars[item][hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | ansible.utils.ipwrap]] }}
-        {%- endif }}" \
+      -hostname={{ hostvars[item]['ansible_hostname'] }},{{ hostvars[item]['ansible_default_ipv4']['address'] }},{{ hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address'] }} \
       -profile=kubernetes \
-        cert-"{{ item }}"-csr.json \
-      | cfssljson -bare cert-"{{ item }}"
+      cert-{{ item }}-csr.json \
+    | cfssljson -bare cert-{{ item }}
   args:
     executable: "/bin/bash"
     chdir: "{{ k8s_ca_conf_directory }}"
     creates: "{{ k8s_ca_conf_directory }}/cert-{{ item }}-key.pem"
   with_inventory_hostnames:
     - "{{ k8s_ca_worker_nodes_group }}"
+  when:
+    - k8s_address_family == "ipv4"
+  tags:
+    - kubernetes-ca
+
+- name: Generate TLS certificates for Kubernetes worker hosts (kubelet) (IPv6)
+  shell: >
+    set -o errexit; \
+    set -o pipefail; \
+    cfssl gencert \
+      -ca=ca-k8s-apiserver.pem \
+      -ca-key=ca-k8s-apiserver-key.pem \
+      -config=ca-k8s-apiserver-config.json \
+      -hostname={{ hostvars[item]['ansible_hostname'] }},{{ hostvars[item]['ansible_default_ipv6']['address'] }},{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] }} \
+      -profile=kubernetes \
+      cert-{{ item }}-csr.json \
+    | cfssljson -bare cert-{{ item }}
+  args:
+    executable: "/bin/bash"
+    chdir: "{{ k8s_ca_conf_directory }}"
+    creates: "{{ k8s_ca_conf_directory }}/cert-{{ item }}-key.pem"
+  with_inventory_hostnames:
+    - "{{ k8s_ca_worker_nodes_group }}"
+  when:
+    - k8s_address_family == "ipv6"
   tags:
     - kubernetes-ca
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,12 +23,20 @@
 
 - name: Generate list of IP addresses and hostnames needed for etcd certificate
   set_fact:
-    etcdHosts: >-
-      {% set comma = joiner(",") %}{% for item in groups[k8s_ca_etcd_nodes_group] -%}
+  etcdHosts: >-
+    {% set comma = joiner(",") %}
+    {% if k8s_address_family == "ipv4" %}
+      {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
         {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
-      {%- endfor %}{% for item in etcd_cert_hosts -%}
-        {{ comma() }}{{ item }}
-      {%- endfor %}
+      {%- endfor -%}
+    {% elif k8s_address_family == "ipv6" %}
+      {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
+        {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv6.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+      {%- endfor -%}
+    {% endif %}
+    {%- for item in etcd_cert_hosts -%}
+      {{ comma() }}{{ item }}
+    {%- endfor %}
   tags:
     - kubernetes-ca
     - kubernetes-ca-etcd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,11 +11,11 @@
       {% set comma = joiner(",") %}
       {% if k8s_address_family == "ipv4" %}
         {%- for item in groups[k8s_ca_controller_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_" + hostvars[item][k8s_interface]]['ipv4']['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_controller_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_" + hostvars[item][k8s_interface]]['ipv6']['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in k8s_apiserver_cert_hosts -%}
@@ -35,11 +35,11 @@
       {% set comma = joiner(",") %}
       {% if k8s_address_family == "ipv4" %}
         {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item][k8s_interface]].ipv4.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv4.address }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_"+hostvars[item][k8s_interface]].ipv6.address }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in etcd_cert_hosts -%}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -394,17 +394,17 @@
       -ca=ca-k8s-apiserver.pem \
       -ca-key=ca-k8s-apiserver-key.pem \
       -config=ca-k8s-apiserver-config.json \
-      - hostname={{ hostvars[item]['ansible_hostname'] }},
+      - hostname="{{ hostvars[item]['ansible_hostname'] }},
         {%- if k8s_address_family == "ipv4" %}
         {{ hostvars[item]['ansible_default_ipv4']['address'] }},
         {{ hostvars[item][hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address']] }}
         {%- elif k8s_address_family == "ipv6" %}
         {{ hostvars[item]['ansible_default_ipv6']['address'] }},
         {{ hostvars[item][hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | ansible.utils.ipwrap]] }}
-        {%- endif }} \
+        {%- endif }}" \
       -profile=kubernetes \
-        cert-{{ item }}-csr.json \
-      | cfssljson -bare cert-{{ item }}
+        cert-"{{ item }}"-csr.json \
+      | cfssljson -bare cert-"{{ item }}"
   args:
     executable: "/bin/bash"
     chdir: "{{ k8s_ca_conf_directory }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
         {%- endfor -%}
       {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_controller_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | ansible.utils.ipwrap }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | ansible.utils.ipwrap }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | quote }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | quote }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in k8s_apiserver_cert_hosts -%}
@@ -39,7 +39,7 @@
         {%- endfor -%}
       {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | ansible.utils.ipwrap }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | ansible.utils.ipwrap }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | quote }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | quote }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in etcd_cert_hosts -%}
@@ -266,7 +266,7 @@
       -ca=ca-etcd.pem \
       -ca-key=ca-etcd-key.pem \
       -config=ca-etcd-config.json \
-      -hostname={{ etcdHosts | ansible.utils.ipwrap | quote }} \
+      -hostname={{ etcdHosts | quote }} \
       -profile=server \
       cert-etcd-server-csr.json \
     | cfssljson -bare cert-etcd-server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
         {%- endfor -%}
       {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_controller_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | ansible.utils.ipwrap }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | ansible.utils.ipwrap }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in k8s_apiserver_cert_hosts -%}
@@ -39,7 +39,7 @@
         {%- endfor -%}
       {% elif k8s_address_family == "ipv6" %}
         {%- for item in groups[k8s_ca_etcd_nodes_group] -%}
-          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
+          {{ comma() }}{{ hostvars[item].ansible_default_ipv6.address | ansible.utils.ipwrap }}{{ comma() }}{{ hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | ansible.utils.ipwrap }}{{ comma() }}{{ item }}{{ comma() }}{{ hostvars[item]["ansible_hostname"] }}
         {%- endfor -%}
       {% endif %}
       {%- for item in etcd_cert_hosts -%}
@@ -266,7 +266,7 @@
       -ca=ca-etcd.pem \
       -ca-key=ca-etcd-key.pem \
       -config=ca-etcd-config.json \
-      -hostname={{ etcdHosts }} \
+      -hostname={{ etcdHosts | ansible.utils.ipwrap }} \
       -profile=server \
       cert-etcd-server-csr.json \
     | cfssljson -bare cert-etcd-server
@@ -299,7 +299,7 @@
       -ca=ca-etcd.pem \
       -ca-key=ca-etcd-key.pem \
       -config=ca-etcd-config.json \
-      -hostname={{ etcdHosts }} \
+      -hostname={{ etcdHosts | ansible.utils.ipwrap }} \
       -profile=peer \
       cert-etcd-peer-csr.json \
     | cfssljson -bare cert-etcd-peer
@@ -332,7 +332,7 @@
       -ca=ca-k8s-apiserver.pem \
       -ca-key=ca-k8s-apiserver-key.pem \
       -config=ca-k8s-apiserver-config.json \
-      -hostname={{ k8sApiHosts }} \
+      -hostname={{ k8sApiHosts | ansible.utils.ipwrap }} \
       -profile=kubernetes \
       cert-k8s-apiserver-csr.json \
     | cfssljson -bare cert-k8s-apiserver
@@ -394,10 +394,17 @@
       -ca=ca-k8s-apiserver.pem \
       -ca-key=ca-k8s-apiserver-key.pem \
       -config=ca-k8s-apiserver-config.json \
-      -hostname={{ hostvars[item]['ansible_hostname'] }},{{ hostvars[item]['ansible_default_ipv4']['address'] }},{{ hostvars[item]['ansible_'+hostvars[item]['k8s_interface']].ipv4.address }} \
+      - hostname={{ hostvars[item]['ansible_hostname'] }},
+        {%- if k8s_address_family == "ipv4" %}
+        {{ hostvars[item]['ansible_default_ipv4']['address'] }},
+        {{ hostvars[item][hostvars[item]["ansible_" + k8s_interface]['ipv4'][0]['address']] }}
+        {%- elif k8s_address_family == "ipv6" %}
+        {{ hostvars[item]['ansible_default_ipv6']['address'] }},
+        {{ hostvars[item][hostvars[item]["ansible_" + k8s_interface]['ipv6'][0]['address'] | ansible.utils.ipwrap]] }}
+        {%- endif }} \
       -profile=kubernetes \
-      cert-{{ item }}-csr.json \
-    | cfssljson -bare cert-{{ item }}
+        cert-{{ item }}-csr.json \
+      | cfssljson -bare cert-{{ item }}
   args:
     executable: "/bin/bash"
     chdir: "{{ k8s_ca_conf_directory }}"


### PR DESCRIPTION
This PR adds support for single-stack IPv6 by exposing a `k8s_address_family` variable which can be either `ipv6` or `ipv4`.

This allows Ansible to properly parse the IPv6 address and ensure it's correctly wrapped before arriving at it's destination.