### PR TITLE
11.0.0+1.18.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 defaults:
   run:
-    working-directory: 'githubixx.kubernetes-ca'
+    working-directory: 'githubixx.kubernetes_ca'
 
 jobs:
   release:
@@ -23,7 +23,7 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v2
         with:
-          path: 'githubixx.kubernetes-ca'
+          path: 'githubixx.kubernetes_ca'
 
       - name: Set up Python 3.
         uses: actions/setup-python@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 ---------
 
+**11.0.0+1.18.4**
+
+- **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-ca` to `kubernetes_ca`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
+- rename `githubixx.kubernetes-ca` to `githubixx.kubernetes_ca`
+- `molecule/default/requirements.yml`: remove `githubixx.kubernetes_ca`
+- `meta/main.yml`: added `role_name`
+- added support for Ubuntu 22.04
+- removed support for Ubuntu 16.04 and 18.04 (reached EOL)
+
 **10.0.0+1.18.4**
 
 - add Molecule test

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Example Playbook
 - hosts: k8s_ca
 
   roles:
-    - githubixx.kubernetes-ca
+    - githubixx.kubernetes_ca
 ```
 
 License

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,8 +7,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
-        - bionic
         - focal
   galaxy_tags:
     - tls

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,8 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - focal
+        - "focal"
+        - "jammy"
   galaxy_tags:
     - tls
     - certificate

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,6 +4,7 @@ galaxy_info:
   description: Generate Kubernetes CA plus certificates for etcd and Kubernetes API server
   license: GPLv3
   min_ansible_version: "2.9"
+  role_name: kubernetes_ca
   platforms:
     - name: Ubuntu
       versions:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,4 +9,4 @@
   tasks:
     - name: Generate etcd and K8s TLS certificates
       include_role:
-        name: githubixx.kubernetes-ca
+        name: githubixx.kubernetes_ca

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -5,4 +5,3 @@
 roles:
   - githubixx.ansible_role_wireguard
   - githubixx.cfssl
-  - githubixx.kubernetes_ca

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -5,4 +5,4 @@
 roles:
   - githubixx.ansible_role_wireguard
   - githubixx.cfssl
-  - githubixx.kubernetes-ca
+  - githubixx.kubernetes_ca


### PR DESCRIPTION
- **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-ca` to `kubernetes_ca`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
- rename `githubixx.kubernetes-ca` to `githubixx.kubernetes_ca`
- `molecule/default/requirements.yml`: remove `githubixx.kubernetes_ca`
- `meta/main.yml`: added `role_name`
- added support for Ubuntu 22.04
- removed support for Ubuntu 16.04 and 18.04 (reached EOL)